### PR TITLE
fix(client): return query params in $url

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -847,6 +847,27 @@ describe('$url() with a param option', () => {
   })
 })
 
+describe('$url() with a query option', () => {
+  const app = new Hono().get(
+    '/posts',
+    validator('query', () => {
+      return {} as { filter: 'test' }
+    }),
+    (c) => c.json({ ok: true })
+  )
+  type AppType = typeof app
+  const client = hc<AppType>('http://localhost')
+
+  it('Should return the correct path - /posts?filter=test', async () => {
+    const url = client.posts.$url({
+      query: {
+        filter: 'test',
+      },
+    })
+    expect(url.search).toBe('?filter=test')
+  })
+})
+
 describe('Client can be awaited', () => {
   it('Can be awaited without side effects', async () => {
     const client = hc('http://localhost')

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -38,7 +38,11 @@ export type ClientRequest<S extends Schema> = {
   $url: (
     arg?: S[keyof S] extends { input: infer R }
       ? R extends { param: infer P }
-        ? { param: P }
+        ? R extends { query: infer Q }
+          ? { param: P; query: Q }
+          : { param: P }
+        : R extends { query: infer Q }
+        ? { query: Q }
         : {}
       : {}
   ) => URL

--- a/src/client/utils.test.ts
+++ b/src/client/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildSearchParams,
   deepMerge,
   mergePath,
   removeIndexString,
@@ -56,6 +57,18 @@ describe('replaceUrlParams', () => {
     }
     const replacedUrl = replaceUrlParam(url, params)
     expect(replacedUrl).toBe('http://localhost/something/123/456')
+  })
+})
+
+describe('buildSearchParams', () => {
+  it('Should build URLSearchParams correctly', () => {
+    const query = {
+      id: '123',
+      type: 'test',
+      tag: ['a', 'b'],
+    }
+    const searchParams = buildSearchParams(query)
+    expect(searchParams.toString()).toBe('id=123&type=test&tag=a&tag=b')
   })
 })
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -15,6 +15,26 @@ export const replaceUrlParam = (urlString: string, params: Record<string, string
   return urlString
 }
 
+export const buildSearchParams = (query: Record<string, string | string[]>) => {
+  const searchParams = new URLSearchParams()
+
+  for (const [k, v] of Object.entries(query)) {
+    if (v === undefined) {
+      continue
+    }
+
+    if (Array.isArray(v)) {
+      for (const v2 of v) {
+        searchParams.append(k, v2)
+      }
+    } else {
+      searchParams.set(k, v)
+    }
+  }
+
+  return searchParams
+}
+
 export const replaceUrlProtocol = (urlString: string, protocol: 'ws' | 'http') => {
   switch (protocol) {
     case 'ws':


### PR DESCRIPTION
Resolves #3532. I'm not sure if there's a more concise way to write the type definition, or to write a test for it, but I was able to validate that it's working as expected locally.

## PR checklist

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
